### PR TITLE
Fix registry links on install (cli) commands for Timeline, Flip Clock, and Heatmap

### DIFF
--- a/lib/docs/components/flip-clock.mdx
+++ b/lib/docs/components/flip-clock.mdx
@@ -17,7 +17,7 @@ description: A flip clock component for displaying time with animated flipping d
 <TabsContent value="cli">
 
 ```bash
-npx shadcn@latest add https://ui.8starlabs.com/r/flip-clock
+npx shadcn@latest add https://ui.8starlabs.com/r/flip-clock.json
 ```
 
 </TabsContent>

--- a/lib/docs/components/heatmap.mdx
+++ b/lib/docs/components/heatmap.mdx
@@ -17,7 +17,7 @@ description: A heatmap component to visualize data density over time.
 <TabsContent value="cli">
 
 ```bash
-npx shadcn@latest add https://ui.8starlabs.com/r/heatmap
+npx shadcn@latest add https://ui.8starlabs.com/r/heatmap.json
 ```
 
 </TabsContent>

--- a/lib/docs/components/timeline.mdx
+++ b/lib/docs/components/timeline.mdx
@@ -17,7 +17,7 @@ description: A timeline component that displays events with customizable orienta
 <TabsContent value="cli">
 
 ```bash
-npx shadcn@latest add https://ui.8starlabs.com/r/timeline
+npx shadcn@latest add https://ui.8starlabs.com/r/timeline.json
 ```
 
 </TabsContent>


### PR DESCRIPTION
Missing `json` file extension in registry link for the following component documents:

- [Timeline](https://ui.8starlabs.com/docs/components/timeline): `lib/docs/components/timeline.mdx`
- [Flip Clock](https://ui.8starlabs.com/docs/components/flip-clock): `lib/docs/components/flip-clock.mdx`
- [Heatmap](https://ui.8starlabs.com/docs/components/heatmap): `lib/docs/components/heatmap.mdx`

Example **failed** timeline cli install command followed by **fixed** one:
<img width="1510" height="681" alt="image" src="https://github.com/user-attachments/assets/d4a01227-7df6-46af-a7b9-57887d47a412" />