### PR TITLE
config(feat): add free PR review setup

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,83 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+enable_free_tier: true
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  review_status: true
+  review_details: true
+  commit_status: true
+  fail_commit_status: false
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: false
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: true
+  auto_assign_reviewers: false
+  poem: false
+  in_progress_fortune: false
+  enable_prompt_for_ai_agents: true
+  abort_on_close: true
+  path_filters:
+    - "!public/r/**"
+    - "!registry/__index__.tsx"
+  path_instructions:
+    - path: "registry/8starlabs-ui/blocks/**/*.{ts,tsx}"
+      instructions: |
+        Review as source for installable registry components. Check accessibility,
+        client/server boundaries, controlled and uncontrolled behavior,
+        composability, TypeScript public API shape, and compatibility with
+        shadcn-style consumption.
+    - path: "registry/8starlabs-ui/examples/**/*.{ts,tsx}"
+      instructions: |
+        Verify examples are minimal, copyable, and aligned with the documented
+        component API. Flag examples that require undeclared dependencies,
+        hidden local state, or imports that will not work for consumers.
+    - path: "lib/docs/**/*.{md,mdx}"
+      instructions: |
+        Treat docs as user-facing API. Check commands, component names, prop
+        descriptions, installation steps, and accessibility notes against the
+        registry source.
+    - path: ".github/**/*"
+      instructions: |
+        Review automation and repository policy changes for least privilege,
+        untrusted input handling, token exposure, and maintainer handoff clarity.
+  auto_review:
+    enabled: false
+    drafts: false
+    description_keyword: "coderabbit:review"
+    labels:
+      - "ai-review"
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+      - "[skip review]"
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "renovate[bot]"
+      - "github-actions[bot]"
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+  learnings:
+    scope: "local"
+  issues:
+    scope: "local"
+  pull_requests:
+    scope: "local"
+  web_search:
+    enabled: true
+
+chat:
+  auto_reply: false
+  art: false

--- a/.github/AI_CODE_REVIEW.md
+++ b/.github/AI_CODE_REVIEW.md
@@ -1,0 +1,72 @@
+# AI Code Review
+
+This repository uses CodeRabbit as the default free, comment-triggered AI
+review path for issue
+[#42](https://github.com/8starlabs/ui/issues/42). CodeRabbit is configured in
+[`.coderabbit.yaml`](../.coderabbit.yaml) so review behavior is versioned with
+the repository instead of living only in an external dashboard.
+
+## Maintainer Setup
+
+1. Install
+   [CodeRabbit from the GitHub Marketplace](https://github.com/marketplace/coderabbitai)
+   for `8starlabs/ui`.
+2. Select the Open Source plan for this public repository.
+3. Confirm CodeRabbit can read `.coderabbit.yaml` from the repository root.
+4. On a test pull request, comment `@coderabbitai configuration` to verify the
+   resolved settings.
+5. Trigger the first review with `@coderabbitai full review`.
+
+## PR Commands
+
+Use these comments on a pull request after the GitHub App is installed:
+
+- `@coderabbitai review` - incremental review of new changes.
+- `@coderabbitai full review` - complete review of the full PR diff.
+- `@coderabbitai pause` - pause review activity on a noisy work-in-progress PR.
+- `@coderabbitai resume` - resume review activity after a pause.
+
+Automatic reviews are disabled by default. Maintainers can still opt a PR into
+review without a comment by adding the `ai-review` label or putting
+`coderabbit:review` in the PR description.
+
+## Why CodeRabbit
+
+Research snapshot: 2026-06-10.
+
+- CodeRabbit is the default for this repository because its GitHub Marketplace
+  listing advertises a $0 Open Source Pro plan for open-source projects, and
+  its documented PR commands support manual comment triggers such as
+  `@coderabbitai review`.
+- Codex is documented as an optional exact-trigger alternative because official
+  Codex docs support `@codex review`, but the pricing docs list cloud-based
+  integrations like automatic code review under Plus and higher plans. The API
+  key path is also pay-per-token and does not include cloud code review.
+- Gemini Code Assist was not selected because Google documents a `/gemini`
+  comment flow, but its consumer GitHub version is scheduled to stop serving
+  requests on July 17, 2026, and the enterprise path requires Google Cloud
+  setup.
+
+Relevant docs:
+
+- [CodeRabbit GitHub Marketplace](https://github.com/marketplace/coderabbitai)
+- [CodeRabbit YAML configuration](https://docs.coderabbit.ai/getting-started/yaml-configuration)
+- [CodeRabbit review commands](https://docs.coderabbit.ai/reference/review-commands)
+- [CodeRabbit automatic review controls](https://docs.coderabbit.ai/configuration/auto-review)
+- [Codex code review in GitHub](https://developers.openai.com/codex/integrations/github)
+- [Codex pricing](https://developers.openai.com/codex/pricing)
+- [Gemini Code Assist GitHub review docs](https://docs.cloud.google.com/gemini/docs/code-review/review-repo-code)
+
+## Review Scope
+
+The default review profile is intentionally calm and manual:
+
+- no automatic review on every PR open or push
+- no request-changes workflow
+- no generated poems or fortune comments
+- generated registry output is excluded from review noise
+- `AGENTS.md` and `CLAUDE.md` are used as durable review guidance
+
+CodeRabbit should focus on actionable bugs, broken consumer install paths,
+security-sensitive automation mistakes, accessibility regressions, and docs
+that drift from the registry source.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,36 @@
 # 8StarLabs UI Agent Skills
 
 Repo-local skills for working with 8StarLabs UI as both:
+
 - maintainers shipping registry components in this repository
 - consumers integrating `@8starlabs/*` into app projects
 
 ## Skills
 
-| Skill | Use when | Path |
-| --- | --- | --- |
-| `8sl-component-ship` | Adding, updating, documenting, or validating a component in this repo | `skills/8sl-component-ship/SKILL.md` |
-| `8sl-consume-registry` | Installing or integrating 8StarLabs UI into an app | `skills/8sl-consume-registry/SKILL.md` |
-| `8sl-pattern-review` | Reviewing or debugging 8StarLabs UI usage | `skills/8sl-pattern-review/SKILL.md` |
-| `pr-comment` | Drafting a PR description or change summary | `skills/pr-comment/SKILL.md` |
+| Skill                  | Use when                                                              | Path                                   |
+| ---------------------- | --------------------------------------------------------------------- | -------------------------------------- |
+| `8sl-component-ship`   | Adding, updating, documenting, or validating a component in this repo | `skills/8sl-component-ship/SKILL.md`   |
+| `8sl-consume-registry` | Installing or integrating 8StarLabs UI into an app                    | `skills/8sl-consume-registry/SKILL.md` |
+| `8sl-pattern-review`   | Reviewing or debugging 8StarLabs UI usage                             | `skills/8sl-pattern-review/SKILL.md`   |
+| `pr-comment`           | Drafting a PR description or change summary                           | `skills/pr-comment/SKILL.md`           |
 
 ## Notes
 
 - Keep each `SKILL.md` at or below 220 lines.
 - Move overflow detail into per-skill `references/`.
 - Use per-skill `evals/evals.json` for realistic prompt coverage.
+
+## Review guidelines
+
+- Prioritize correctness, accessibility, security, consumer installability,
+  generated-registry consistency, and documentation drift over style-only
+  feedback.
+- For Codex reviews, flag only P0/P1 issues. For other AI reviewers, keep
+  comments high signal and actionable.
+- Treat `registry/8starlabs-ui/blocks/**` as public component API. Check
+  TypeScript types, client/server boundaries, shadcn-style consumption, and
+  accessible defaults.
+- Treat `registry/8starlabs-ui/examples/**` and `lib/docs/**` as consumer
+  onboarding surface. Verify examples are copyable and commands remain current.
+- For `.github/**` changes, review least privilege, secret exposure, untrusted
+  input handling, and maintainer setup clarity.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,22 @@ Please include:
 - A closing keyword in the PR description, such as `Closes #123`, `Fixes #123`, or `Resolves #123`, when the PR should automatically close an issue after merge. See GitHub's guide on [linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).
 - The reason or context behind the change
 
+### AI-assisted review
+
+Maintainers can request an AI review on pull requests after the repository's
+CodeRabbit GitHub App is installed. The repository keeps its settings in
+[`.coderabbit.yaml`](.coderabbit.yaml) and documents the full workflow in
+[`.github/AI_CODE_REVIEW.md`](.github/AI_CODE_REVIEW.md).
+
+Use these PR comments when an extra automated review pass is useful:
+
+- `@coderabbitai review` for an incremental review of new changes.
+- `@coderabbitai full review` for a complete review of the full PR diff.
+
+Automatic reviews are disabled by default to keep feedback intentional. A PR can
+also opt in with the `ai-review` label or by adding `coderabbit:review` to the
+PR description.
+
 ## Project Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -3,15 +3,21 @@
   "version": "0.0.1",
   "private": true,
   "packageManager": "pnpm@11.0.9",
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
+    "test": "node --test scripts/*.test.mjs",
     "lint": "eslint .",
     "registry:build": "shadcn build && prettier --write \"public/r/*.json\" --cache",
     "registry:generate-index": "tsx ./scripts/generate-index.mts && prettier --write \"registry/**/*.{ts,tsx,json,mdx}\" --cache",
+    "ai-review:validate": "node scripts/validate-ai-review-config.mjs",
+    "docs:generate": "fumadocs-mdx",
     "prepare": "husky",
-    "tscheck": "tsc --noEmit"
+    "tscheck": "pnpm docs:generate && tsc --noEmit"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,md,mdx}": [
@@ -80,6 +86,7 @@
     "lint-staged": "^16.2.6",
     "prettier": "^3.6.2",
     "tailwindcss": "^4.1.11",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "yaml": "^2.8.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
 
 packages:
 

--- a/scripts/validate-ai-review-config.mjs
+++ b/scripts/validate-ai-review-config.mjs
@@ -1,0 +1,143 @@
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseDocument } from "yaml";
+
+function readProjectFile(root, path) {
+  try {
+    return readFileSync(join(root, path), "utf8");
+  } catch (error) {
+    throw new Error(`Expected ${path} to exist: ${error.message}`);
+  }
+}
+
+function assertIncludes(content, expected, path) {
+  if (!content.includes(expected)) {
+    throw new Error(`Expected ${path} to include ${JSON.stringify(expected)}`);
+  }
+}
+
+function parseYaml(content, path) {
+  const document = parseDocument(content);
+  if (document.errors.length > 0) {
+    throw new Error(
+      `Expected ${path} to contain valid YAML: ${document.errors[0].message}`
+    );
+  }
+
+  return document.toJS();
+}
+
+function assertEqual(actual, expected, path, property) {
+  if (actual !== expected) {
+    throw new Error(
+      `Expected ${path} ${property} to be ${JSON.stringify(expected)}`
+    );
+  }
+}
+
+function assertArrayIncludes(actual, expected, path, property) {
+  if (!Array.isArray(actual) || !actual.includes(expected)) {
+    throw new Error(
+      `Expected ${path} ${property} to include ${JSON.stringify(expected)}`
+    );
+  }
+}
+
+export function validateAiReviewConfig({ root = process.cwd() } = {}) {
+  const coderabbitConfig = readProjectFile(root, ".coderabbit.yaml");
+  const parsedCoderabbitConfig = parseYaml(
+    coderabbitConfig,
+    ".coderabbit.yaml"
+  );
+  const aiReviewDocs = readProjectFile(root, ".github/AI_CODE_REVIEW.md");
+  const contributing = readProjectFile(root, "CONTRIBUTING.md");
+  const agents = readProjectFile(root, "AGENTS.md");
+
+  assertIncludes(
+    coderabbitConfig,
+    "# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json",
+    ".coderabbit.yaml"
+  );
+  assertEqual(
+    parsedCoderabbitConfig.enable_free_tier,
+    true,
+    ".coderabbit.yaml",
+    "enable_free_tier"
+  );
+  assertEqual(
+    parsedCoderabbitConfig.reviews?.auto_review?.enabled,
+    false,
+    ".coderabbit.yaml",
+    "reviews.auto_review.enabled"
+  );
+  assertEqual(
+    parsedCoderabbitConfig.reviews?.auto_review?.description_keyword,
+    "coderabbit:review",
+    ".coderabbit.yaml",
+    "reviews.auto_review.description_keyword"
+  );
+  assertArrayIncludes(
+    parsedCoderabbitConfig.reviews?.auto_review?.labels,
+    "ai-review",
+    ".coderabbit.yaml",
+    "reviews.auto_review.labels"
+  );
+  assertEqual(
+    parsedCoderabbitConfig.reviews?.poem,
+    false,
+    ".coderabbit.yaml",
+    "reviews.poem"
+  );
+  assertEqual(
+    parsedCoderabbitConfig.reviews?.in_progress_fortune,
+    false,
+    ".coderabbit.yaml",
+    "reviews.in_progress_fortune"
+  );
+  assertEqual(
+    parsedCoderabbitConfig.knowledge_base?.code_guidelines?.enabled,
+    true,
+    ".coderabbit.yaml",
+    "knowledge_base.code_guidelines.enabled"
+  );
+
+  for (const command of [
+    "@coderabbitai review",
+    "@coderabbitai full review",
+    "coderabbit:review",
+    "ai-review",
+    "@codex review"
+  ]) {
+    assertIncludes(aiReviewDocs, command, ".github/AI_CODE_REVIEW.md");
+  }
+
+  assertIncludes(
+    aiReviewDocs,
+    "CodeRabbit is the default for this repository",
+    ".github/AI_CODE_REVIEW.md"
+  );
+  assertIncludes(
+    aiReviewDocs,
+    "Codex is documented as an optional exact-trigger alternative",
+    ".github/AI_CODE_REVIEW.md"
+  );
+  assertIncludes(contributing, ".github/AI_CODE_REVIEW.md", "CONTRIBUTING.md");
+  assertIncludes(contributing, "@coderabbitai review", "CONTRIBUTING.md");
+  assertIncludes(agents, "## Review guidelines", "AGENTS.md");
+  assertIncludes(agents, "P0/P1", "AGENTS.md");
+
+  return {
+    filesChecked: [
+      ".coderabbit.yaml",
+      ".github/AI_CODE_REVIEW.md",
+      "CONTRIBUTING.md",
+      "AGENTS.md"
+    ]
+  };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  validateAiReviewConfig();
+  console.log("AI review configuration validated.");
+}

--- a/scripts/validate-ai-review-config.test.mjs
+++ b/scripts/validate-ai-review-config.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const repositoryRoot = new URL("..", import.meta.url);
+
+function readRepositoryFile(path) {
+  return readFileSync(new URL(path, repositoryRoot), "utf8");
+}
+
+function createFixture(overrides = {}) {
+  const root = mkdtempSync(join(tmpdir(), "8sl-ai-review-"));
+  mkdirSync(join(root, ".github"), { recursive: true });
+
+  const files = {
+    ".coderabbit.yaml": readRepositoryFile(".coderabbit.yaml"),
+    ".github/AI_CODE_REVIEW.md": readRepositoryFile(
+      ".github/AI_CODE_REVIEW.md"
+    ),
+    "CONTRIBUTING.md": readRepositoryFile("CONTRIBUTING.md"),
+    "AGENTS.md": readRepositoryFile("AGENTS.md"),
+    ...overrides
+  };
+
+  for (const [path, content] of Object.entries(files)) {
+    writeFileSync(join(root, path), content);
+  }
+
+  return root;
+}
+
+test("validates a complete AI review setup", async () => {
+  const { validateAiReviewConfig } = await import(
+    "./validate-ai-review-config.mjs"
+  );
+  const result = validateAiReviewConfig({ root: createFixture() });
+
+  assert.deepEqual(result, {
+    filesChecked: [
+      ".coderabbit.yaml",
+      ".github/AI_CODE_REVIEW.md",
+      "CONTRIBUTING.md",
+      "AGENTS.md"
+    ]
+  });
+});
+
+test("accepts semantic CodeRabbit config regardless of YAML order", async () => {
+  const { validateAiReviewConfig } = await import(
+    "./validate-ai-review-config.mjs"
+  );
+  const root = createFixture({
+    ".coderabbit.yaml": `# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+enable_free_tier: true
+knowledge_base:
+  code_guidelines: { enabled: true }
+reviews:
+  poem: false
+  in_progress_fortune: false
+  auto_review:
+    labels: [ai-review]
+    description_keyword: coderabbit:review
+    enabled: false
+`
+  });
+  const result = validateAiReviewConfig({ root });
+
+  assert.equal(result.filesChecked.length, 4);
+});
+
+test("rejects accidental automatic CodeRabbit reviews", async () => {
+  const { validateAiReviewConfig } = await import(
+    "./validate-ai-review-config.mjs"
+  );
+  const root = createFixture({
+    ".coderabbit.yaml": readRepositoryFile(".coderabbit.yaml").replace(
+      "auto_review:\n    enabled: false",
+      "auto_review:\n    enabled: true"
+    )
+  });
+
+  assert.throws(
+    () => validateAiReviewConfig({ root }),
+    /Expected \.coderabbit\.yaml reviews\.auto_review\.enabled to be false/
+  );
+});
+
+test("rejects docs that omit the full review trigger", async () => {
+  const { validateAiReviewConfig } = await import(
+    "./validate-ai-review-config.mjs"
+  );
+  const root = createFixture({
+    ".github/AI_CODE_REVIEW.md": readRepositoryFile(
+      ".github/AI_CODE_REVIEW.md"
+    ).replaceAll("@coderabbitai full review", "@coderabbitai complete review")
+  });
+
+  assert.throws(
+    () => validateAiReviewConfig({ root }),
+    /Expected \.github\/AI_CODE_REVIEW\.md to include/
+  );
+});
+
+test("package.json exposes AI review tests", () => {
+  const packageJson = JSON.parse(readRepositoryFile("package.json"));
+
+  assert.equal(packageJson.scripts.test, "node --test scripts/*.test.mjs");
+  assert.equal(
+    packageJson.scripts["ai-review:validate"],
+    "node scripts/validate-ai-review-config.mjs"
+  );
+  assert.equal(packageJson.engines.node, ">=20.9.0");
+});


### PR DESCRIPTION
## Summary

Adds a free, manual AI review path for pull requests using CodeRabbit, with
repo-versioned settings and maintainer documentation. The setup resolves issue
#42 without introducing API-key workflows or paid Codex cloud requirements.

## Key Changes

- Add manual-only CodeRabbit config with free-tier enabled, review scope
  instructions, generated-output filters, and `ai-review`/`coderabbit:review`
  opt-in controls.
- Document maintainer setup, supported PR comment triggers, and the researched
  Codex/Gemini tradeoffs.
- Add validation tests for the AI review config and make `tscheck` generate
  Fumadocs sources before TypeScript.

Closes #42