### PR TITLE
config(feat): add manual ai pr review setup

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+tone_instructions: "Be concise, direct, and high-signal. Prioritize correctness, regressions, accessibility, security, maintainability, documentation drift, and missing validation. Avoid style-only comments unless they prevent real confusion."
+early_access: false
+enable_free_tier: true
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  review_details: false
+  commit_status: true
+  fail_commit_status: false
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: false
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: true
+  auto_assign_reviewers: false
+  poem: false
+  enable_prompt_for_ai_agents: true
+  abort_on_close: true
+  path_filters:
+    - "!public/r/**"
+    - "!registry/__index__.tsx"
+    - "!pnpm-lock.yaml"
+    - "!**/*.tsbuildinfo"
+  path_instructions:
+    - path: "registry/8starlabs-ui/blocks/**/*.tsx"
+      instructions: |
+        Review these as public registry components. Flag public API changes without matching examples and docs, accessibility regressions, broken client/server boundaries, unstable class composition, missing TypeScript coverage, and behavior that would make shadcn installs harder to maintain.
+    - path: "registry/8starlabs-ui/examples/**/*.tsx"
+      instructions: |
+        Check that examples are realistic, compile independently, use the exported component APIs correctly, and remain small enough for docs readers to copy. Flag examples that depend on private app-only helpers.
+    - path: "lib/docs/**/*.mdx"
+      instructions: |
+        Treat documentation drift as a functional issue. Flag missing installation steps, stale props, unclear usage examples, inaccessible language, and docs that no longer match registry component behavior.
+    - path: "app/**/*.{ts,tsx}"
+      instructions: |
+        Review Next.js App Router code for server/client boundary mistakes, metadata and routing regressions, unstable generated content, and user-visible performance or accessibility issues.
+    - path: "components/**/*.{ts,tsx}"
+      instructions: |
+        Check shared UI for reusable, accessible, typed APIs. Flag layout shifts, keyboard navigation gaps, hydration risks, and coupling to one documentation page when a general component is expected.
+    - path: "hooks/**/*.{ts,tsx}"
+      instructions: |
+        Check hooks for stable dependencies, browser-only API guards, cleanup of listeners/observers, and behavior under React Strict Mode.
+    - path: "lib/**/*.{ts,tsx}"
+      instructions: |
+        Review shared utilities for deterministic behavior, safe parsing, explicit error cases, and compatibility with both build-time and runtime execution.
+    - path: ".github/**"
+      instructions: |
+        Treat secret exposure, broad token permissions, unpinned third-party actions, pull_request_target usage, and any workflow that writes to untrusted pull request code as high-priority risks.
+  auto_review:
+    enabled: false
+    auto_incremental_review: false
+    auto_pause_after_reviewed_commits: 3
+    drafts: false
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+      - "[skip review]"
+
+chat:
+  auto_reply: true

--- a/.github/AI_REVIEW.md
+++ b/.github/AI_REVIEW.md
@@ -1,0 +1,52 @@
+# AI Pull Request Review
+
+This repository is configured for manual AI review on pull requests.
+
+## Selected Provider
+
+Use CodeRabbit as the default review bot.
+
+Why this setup:
+
+- The GitHub Marketplace says CodeRabbit's Open Source Pro plan is free for Open Source projects.
+- It does not require repository API keys, paid model secrets, or a custom GitHub Actions bot.
+- It supports pull request comment triggers such as `@coderabbitai review` and `@coderabbitai full review`.
+- The repository keeps review behavior in version control through `.coderabbit.yaml`.
+
+Automatic reviews are disabled in `.coderabbit.yaml` so review budget is spent only when maintainers ask for it.
+
+## Maintainer Setup
+
+1. Install the CodeRabbit GitHub App for `8starlabs/ui`.
+2. Select the Open Source plan for the public repository.
+3. Confirm CodeRabbit detects `.coderabbit.yaml` by commenting `@coderabbitai configuration` on a test pull request.
+4. Request the first incremental review by commenting `@coderabbitai review`.
+5. Use `@coderabbitai full review` when a pull request needs a complete fresh pass.
+
+## Pull Request Commands
+
+- `@coderabbitai review` requests an incremental review of new changes.
+- `@coderabbitai full review` requests a complete review of the full pull request.
+- `@coderabbitai pause` pauses automatic review behavior for a pull request if maintainers enable automatic reviews later.
+- `@coderabbitai resume` resumes paused review behavior.
+- `@coderabbitai help` shows the current command reference in the pull request.
+
+## Codex Compatibility
+
+The issue requested a workflow like `@codex review`. Codex code review is an optional external integration that maintainers can enable separately in Codex settings. If enabled, the exact `@codex review` pull request comment should follow the repository-level guidance in `AGENTS.md`.
+
+CodeRabbit remains the default free/open-source setup in this repository because it can be configured by committed files and does not require OpenAI API secrets in GitHub Actions.
+
+## Review Policy
+
+AI review is advisory. Maintainers remain responsible for final review, testing, and merge decisions.
+
+Reviewers should ask the bot for another pass after meaningful changes, especially when a pull request touches:
+
+- public component APIs in `registry/8starlabs-ui/blocks`
+- examples or docs that must stay synchronized with component behavior
+- GitHub Actions or repository automation
+- accessibility-sensitive UI behavior
+- build, registry, or TypeScript configuration
+
+Generated registry output under `public/r/**` and `registry/__index__.tsx` is excluded from CodeRabbit review focus so reviewers spend attention on source inputs instead of generated artifacts.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+-
+
+## Testing
+
+-
+
+## Related Issue
+
+<!-- Use a closing keyword when this PR should close an issue, for example: Closes #<issue-number> -->
+
+## Screenshots or Recordings
+
+<!-- Include screenshots or recordings for UI-facing changes. Delete this section if it does not apply. -->
+
+## AI Review
+
+<!-- Optional after opening the PR: comment `@coderabbitai review` for an incremental review or `@coderabbitai full review` for a complete pass. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,38 @@
 # 8StarLabs UI Agent Skills
 
 Repo-local skills for working with 8StarLabs UI as both:
+
 - maintainers shipping registry components in this repository
 - consumers integrating `@8starlabs/*` into app projects
 
 ## Skills
 
-| Skill | Use when | Path |
-| --- | --- | --- |
-| `8sl-component-ship` | Adding, updating, documenting, or validating a component in this repo | `skills/8sl-component-ship/SKILL.md` |
-| `8sl-consume-registry` | Installing or integrating 8StarLabs UI into an app | `skills/8sl-consume-registry/SKILL.md` |
-| `8sl-pattern-review` | Reviewing or debugging 8StarLabs UI usage | `skills/8sl-pattern-review/SKILL.md` |
-| `pr-comment` | Drafting a PR description or change summary | `skills/pr-comment/SKILL.md` |
+| Skill                  | Use when                                                              | Path                                   |
+| ---------------------- | --------------------------------------------------------------------- | -------------------------------------- |
+| `8sl-component-ship`   | Adding, updating, documenting, or validating a component in this repo | `skills/8sl-component-ship/SKILL.md`   |
+| `8sl-consume-registry` | Installing or integrating 8StarLabs UI into an app                    | `skills/8sl-consume-registry/SKILL.md` |
+| `8sl-pattern-review`   | Reviewing or debugging 8StarLabs UI usage                             | `skills/8sl-pattern-review/SKILL.md`   |
+| `pr-comment`           | Drafting a PR description or change summary                           | `skills/pr-comment/SKILL.md`           |
 
 ## Notes
 
 - Keep each `SKILL.md` at or below 220 lines.
 - Move overflow detail into per-skill `references/`.
 - Use per-skill `evals/evals.json` for realistic prompt coverage.
+
+## Review guidelines
+
+- Treat `registry/8starlabs-ui` as the public shipping surface. Flag component
+  API changes that do not update matching examples, docs, registry metadata, or
+  generated expectations.
+- For React and Next.js changes, check client/server boundaries, hydration
+  risks, accessibility, keyboard behavior, responsive layout, and TypeScript
+  soundness before style preferences.
+- For docs in `lib/docs`, treat stale installation commands, stale prop names,
+  broken examples, and missing accessibility notes as functional defects.
+- For GitHub automation and repository configuration, flag secret exposure,
+  broad token permissions, unpinned third-party actions, unsafe
+  `pull_request_target` usage, and any workflow that writes to untrusted pull
+  request code.
+- Avoid spending review attention on generated registry files unless the source
+  inputs suggest the generated output is stale or inconsistent.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,23 @@ detail into nearby `references/` files.
    - Include screenshots for UI changes
    - Describe your changes and the rationale behind them
 
+### AI code review
+
+This repository includes a CodeRabbit configuration for free/open-source AI
+pull request review. Maintainers need to install the CodeRabbit GitHub App for
+`8starlabs/ui` once, then the committed `.coderabbit.yaml` controls the review
+behavior.
+
+Automatic reviews are disabled by default so reviews run only when requested.
+After opening a pull request, comment `@coderabbitai review` to request an
+incremental review of new changes, or comment `@coderabbitai full review` for a
+complete fresh pass over the pull request.
+
+The maintainer setup and command reference live in
+[`.github/AI_REVIEW.md`](.github/AI_REVIEW.md). If maintainers also enable Codex
+code review externally, `@codex review` should follow the repository-specific
+review guidelines in [`AGENTS.md`](AGENTS.md).
+
 ## Documentation Standards
 
 - Be Clear: Use simple, clear language

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "registry:build": "shadcn build && prettier --write \"public/r/*.json\" --cache",
     "registry:generate-index": "tsx ./scripts/generate-index.mts && prettier --write \"registry/**/*.{ts,tsx,json,mdx}\" --cache",
     "prepare": "husky",
-    "tscheck": "tsc --noEmit"
+    "test": "node --test \"scripts/*.test.mjs\"",
+    "tscheck": "tsc --noEmit",
+    "validate:ai-review": "node scripts/validate-ai-review-setup.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,md,mdx}": [

--- a/scripts/validate-ai-review-setup.mjs
+++ b/scripts/validate-ai-review-setup.mjs
@@ -1,0 +1,209 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const defaultRepoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+
+function readRequired(repoRoot, relativePath, failures) {
+  const absolutePath = path.join(repoRoot, relativePath);
+
+  if (!existsSync(absolutePath)) {
+    failures.push(`${relativePath} must exist`);
+    return "";
+  }
+
+  return readFileSync(absolutePath, "utf8");
+}
+
+function assertIncludes(file, content, needle, reason, failures) {
+  if (!content.includes(needle)) {
+    failures.push(`${file} must include ${JSON.stringify(needle)} (${reason})`);
+  }
+}
+
+function assertMatches(file, content, pattern, reason, failures) {
+  if (!pattern.test(content)) {
+    failures.push(`${file} must match ${pattern} (${reason})`);
+  }
+}
+
+export function validateAiReviewSetup(repoRoot) {
+  const failures = [];
+
+  if (typeof repoRoot !== "string" || repoRoot.trim().length === 0) {
+    return ["repository root must be a non-empty string"];
+  }
+
+  const codeRabbitConfig = readRequired(repoRoot, ".coderabbit.yaml", failures);
+  const aiReviewGuide = readRequired(
+    repoRoot,
+    ".github/AI_REVIEW.md",
+    failures
+  );
+  const pullRequestTemplate = readRequired(
+    repoRoot,
+    ".github/pull_request_template.md",
+    failures
+  );
+  const contributingGuide = readRequired(repoRoot, "CONTRIBUTING.md", failures);
+  const agentGuide = readRequired(repoRoot, "AGENTS.md", failures);
+
+  assertIncludes(
+    ".coderabbit.yaml",
+    codeRabbitConfig,
+    "https://coderabbit.ai/integrations/schema.v2.json",
+    "pin the public CodeRabbit schema for editor validation",
+    failures
+  );
+  assertIncludes(
+    ".coderabbit.yaml",
+    codeRabbitConfig,
+    "enable_free_tier: true",
+    "keep the selected reviewer compatible with the free open-source plan",
+    failures
+  );
+  assertMatches(
+    ".coderabbit.yaml",
+    codeRabbitConfig,
+    /auto_review:\n(?: {4}.+\n)* {4}enabled: false/,
+    "manual comments should trigger reviews instead of automatic review spam",
+    failures
+  );
+  assertIncludes(
+    ".coderabbit.yaml",
+    codeRabbitConfig,
+    "!public/r/**",
+    "generated registry JSON should not consume review attention",
+    failures
+  );
+  assertIncludes(
+    ".coderabbit.yaml",
+    codeRabbitConfig,
+    "registry/8starlabs-ui/blocks/**/*.tsx",
+    "component blocks need path-specific review guidance",
+    failures
+  );
+  assertIncludes(
+    ".coderabbit.yaml",
+    codeRabbitConfig,
+    ".github/**",
+    "workflow and contribution files need security-focused guidance",
+    failures
+  );
+
+  assertIncludes(
+    ".github/AI_REVIEW.md",
+    aiReviewGuide,
+    "CodeRabbit",
+    "document the selected free review provider",
+    failures
+  );
+  assertIncludes(
+    ".github/AI_REVIEW.md",
+    aiReviewGuide,
+    "Open Source Pro plan is free",
+    "explain the free/open-source basis for the choice",
+    failures
+  );
+  assertIncludes(
+    ".github/AI_REVIEW.md",
+    aiReviewGuide,
+    "@coderabbitai review",
+    "document the manual PR comment trigger",
+    failures
+  );
+  assertIncludes(
+    ".github/AI_REVIEW.md",
+    aiReviewGuide,
+    "@coderabbitai full review",
+    "document the full-review PR comment trigger",
+    failures
+  );
+  assertIncludes(
+    ".github/AI_REVIEW.md",
+    aiReviewGuide,
+    "@codex review",
+    "document the Codex-compatible review path requested in the issue",
+    failures
+  );
+
+  assertIncludes(
+    ".github/pull_request_template.md",
+    pullRequestTemplate,
+    "@coderabbitai review",
+    "make the manual review trigger visible on every PR",
+    failures
+  );
+  assertIncludes(
+    ".github/pull_request_template.md",
+    pullRequestTemplate,
+    "Closes #",
+    "preserve issue-closing hygiene for contributors",
+    failures
+  );
+
+  assertIncludes(
+    "CONTRIBUTING.md",
+    contributingGuide,
+    "AI code review",
+    "contributors need to know how the review flow works",
+    failures
+  );
+  assertIncludes(
+    "CONTRIBUTING.md",
+    contributingGuide,
+    "@coderabbitai review",
+    "the contribution guide should mention the PR comment trigger",
+    failures
+  );
+
+  assertIncludes(
+    "AGENTS.md",
+    agentGuide,
+    "## Review guidelines",
+    "Codex and other agents need durable repository review guidance",
+    failures
+  );
+  assertIncludes(
+    "AGENTS.md",
+    agentGuide,
+    "registry/8starlabs-ui",
+    "review guidance must cover the registry component surface",
+    failures
+  );
+  assertIncludes(
+    "AGENTS.md",
+    agentGuide,
+    "pull_request_target",
+    "review guidance must flag high-risk GitHub Actions patterns",
+    failures
+  );
+
+  return failures;
+}
+
+function runCli() {
+  const failures = validateAiReviewSetup(defaultRepoRoot);
+
+  if (failures.length > 0) {
+    console.error("AI review setup validation failed:");
+
+    for (const failure of failures) {
+      console.error(`- ${failure}`);
+    }
+
+    process.exit(1);
+  }
+
+  console.log("AI review setup validation passed.");
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  runCli();
+}

--- a/scripts/validate-ai-review-setup.test.mjs
+++ b/scripts/validate-ai-review-setup.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { validateAiReviewSetup } from "./validate-ai-review-setup.mjs";
+
+function createFixture(files) {
+  const root = mkdtempSync(path.join(tmpdir(), "8sl-ai-review-"));
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const absolutePath = path.join(root, relativePath);
+
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, content, "utf8");
+  }
+
+  return root;
+}
+
+function validFiles(overrides = {}) {
+  return {
+    ".coderabbit.yaml": [
+      "# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json",
+      "enable_free_tier: true",
+      "reviews:",
+      "  path_filters:",
+      '    - "!public/r/**"',
+      "  path_instructions:",
+      '    - path: "registry/8starlabs-ui/blocks/**/*.tsx"',
+      '    - path: ".github/**"',
+      "  auto_review:",
+      "    enabled: false"
+    ].join("\n"),
+    ".github/AI_REVIEW.md": [
+      "CodeRabbit",
+      "Open Source Pro plan is free",
+      "@coderabbitai review",
+      "@coderabbitai full review",
+      "@codex review"
+    ].join("\n"),
+    ".github/pull_request_template.md": [
+      "@coderabbitai review",
+      "Closes #<issue-number>"
+    ].join("\n"),
+    "CONTRIBUTING.md": ["AI code review", "@coderabbitai review"].join("\n"),
+    "AGENTS.md": [
+      "## Review guidelines",
+      "registry/8starlabs-ui",
+      "pull_request_target"
+    ].join("\n"),
+    ...overrides
+  };
+}
+
+test("returns no failures for a complete AI review setup", () => {
+  const root = createFixture(validFiles());
+
+  try {
+    assert.deepEqual(validateAiReviewSetup(root), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("reports missing files without throwing", () => {
+  const root = createFixture({});
+
+  try {
+    const failures = validateAiReviewSetup(root);
+
+    assert.ok(failures.includes(".coderabbit.yaml must exist"));
+    assert.ok(failures.includes(".github/AI_REVIEW.md must exist"));
+    assert.ok(failures.includes(".github/pull_request_template.md must exist"));
+    assert.ok(failures.includes("CONTRIBUTING.md must exist"));
+    assert.ok(failures.includes("AGENTS.md must exist"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("reports empty documentation and malformed auto review config", () => {
+  const root = createFixture(
+    validFiles({
+      ".coderabbit.yaml": [
+        "# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json",
+        "enable_free_tier: true",
+        "reviews:",
+        "  auto_review:",
+        "    enabled: true"
+      ].join("\n"),
+      ".github/AI_REVIEW.md": "",
+      ".github/pull_request_template.md": "",
+      "CONTRIBUTING.md": "",
+      "AGENTS.md": ""
+    })
+  );
+
+  try {
+    const failures = validateAiReviewSetup(root);
+
+    assert.ok(
+      failures.some((failure) =>
+        failure.includes("manual comments should trigger reviews")
+      )
+    );
+    assert.ok(
+      failures.some((failure) =>
+        failure.includes("document the selected free review provider")
+      )
+    );
+    assert.ok(
+      failures.some((failure) =>
+        failure.includes("contributors need to know how the review flow works")
+      )
+    );
+    assert.ok(
+      failures.some((failure) =>
+        failure.includes("Codex and other agents need durable")
+      )
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("reports invalid repository roots gracefully", () => {
+  assert.deepEqual(validateAiReviewSetup(null), [
+    "repository root must be a non-empty string"
+  ]);
+  assert.deepEqual(validateAiReviewSetup(""), [
+    "repository root must be a non-empty string"
+  ]);
+  assert.deepEqual(validateAiReviewSetup("   "), [
+    "repository root must be a non-empty string"
+  ]);
+});


### PR DESCRIPTION
## Summary
- Adds a free/manual AI PR review setup for issue #42 using CodeRabbit.
- Documents maintainer setup, PR trigger commands, and Codex-compatible review guidance.
- Adds validation and tests to keep the review setup from regressing.

## Verification
- npm test
- pnpm validate:ai-review
- pnpm exec prettier --check package.json scripts/validate-ai-review-setup.mjs scripts/validate-ai-review-setup.test.mjs .coderabbit.yaml .github/AI_REVIEW.md .github/pull_request_template.md AGENTS.md CONTRIBUTING.md
- ruby -e "require 'yaml'; YAML.load_file('.coderabbit.yaml'); puts 'YAML syntax OK'"
- pnpm lint
- pnpm tscheck
- pnpm build

Closes #42
