### PR TITLE
config(feat): add maintainer-triggered PR review setup

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,91 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+enable_free_tier: true
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  review_status: true
+  review_details: true
+  commit_status: true
+  fail_commit_status: false
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: false
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: false
+  auto_assign_reviewers: false
+  in_progress_fortune: false
+  poem: false
+  enable_prompt_for_ai_agents: true
+  abort_on_close: true
+  path_filters:
+    - "!pnpm-lock.yaml"
+    - "!public/r/**"
+    - "!registry/__index__.tsx"
+  path_instructions:
+    - path: "registry/8starlabs-ui/blocks/**/*.{ts,tsx}"
+      instructions: >-
+        Review component changes for stable public APIs, accessible interaction
+        states, shadcn-compatible import paths, Tailwind class merging, and
+        backwards-compatible defaults. Flag stale examples, docs, or registry
+        metadata whenever component behavior changes.
+    - path: "registry/8starlabs-ui/examples/**/*.{ts,tsx}"
+      instructions: >-
+        Review examples as public documentation. Confirm they compile, remain
+        copy-paste friendly, and demonstrate the current component API without
+        hidden local assumptions.
+    - path: "lib/docs/**/*.mdx"
+      instructions: >-
+        Review docs for installation accuracy, working component preview names,
+        current prop tables, and plain contributor-friendly language.
+    - path: ".github/**/*"
+      instructions: >-
+        Review GitHub configuration for least-privilege permissions, safe
+        external-service triggers, and clear maintainer ownership.
+  auto_review:
+    enabled: false
+    auto_incremental_review: false
+    auto_pause_after_reviewed_commits: 3
+    drafts: false
+    labels:
+      - "review-ready"
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+      - "[skip review]"
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "github-actions[bot]"
+
+chat:
+  art: false
+  allow_non_org_members: false
+  auto_reply: false
+
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"
+      - "CONTRIBUTING.md"
+      - "skills/**/*.md"
+  learnings:
+    scope: "local"
+  issues:
+    scope: "local"
+  pull_requests:
+    scope: "local"
+  mcp:
+    usage: "auto"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+-
+
+## Related Issues
+
+- Closes #
+
+## Validation
+
+- [ ] `pnpm lint`
+- [ ] `pnpm tscheck`
+- [ ] `pnpm registry:generate-index` (registry/component changes only)
+- [ ] `pnpm registry:build` (registry/component changes only)
+- [ ] Screenshots or screen recording attached (UI changes only)
+
+## Maintainer AI Review
+
+- [ ] Optional: request CodeRabbit with `@coderabbitai full review` for the
+      first pass, `@coderabbitai review` for incremental follow-up, or the
+      `review-ready` label for maintainer opt-in.
+- [ ] Optional: request Codex with `@codex review` when Codex code review is
+      enabled for this repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,40 @@
 # 8StarLabs UI Agent Skills
 
 Repo-local skills for working with 8StarLabs UI as both:
+
 - maintainers shipping registry components in this repository
 - consumers integrating `@8starlabs/*` into app projects
 
 ## Skills
 
-| Skill | Use when | Path |
-| --- | --- | --- |
-| `8sl-component-ship` | Adding, updating, documenting, or validating a component in this repo | `skills/8sl-component-ship/SKILL.md` |
-| `8sl-consume-registry` | Installing or integrating 8StarLabs UI into an app | `skills/8sl-consume-registry/SKILL.md` |
-| `8sl-pattern-review` | Reviewing or debugging 8StarLabs UI usage | `skills/8sl-pattern-review/SKILL.md` |
-| `pr-comment` | Drafting a PR description or change summary | `skills/pr-comment/SKILL.md` |
+| Skill                  | Use when                                                              | Path                                   |
+| ---------------------- | --------------------------------------------------------------------- | -------------------------------------- |
+| `8sl-component-ship`   | Adding, updating, documenting, or validating a component in this repo | `skills/8sl-component-ship/SKILL.md`   |
+| `8sl-consume-registry` | Installing or integrating 8StarLabs UI into an app                    | `skills/8sl-consume-registry/SKILL.md` |
+| `8sl-pattern-review`   | Reviewing or debugging 8StarLabs UI usage                             | `skills/8sl-pattern-review/SKILL.md`   |
+| `pr-comment`           | Drafting a PR description or change summary                           | `skills/pr-comment/SKILL.md`           |
 
 ## Notes
 
 - Keep each `SKILL.md` at or below 220 lines.
 - Move overflow detail into per-skill `references/`.
 - Use per-skill `evals/evals.json` for realistic prompt coverage.
+
+## Review guidelines
+
+- Prioritize correctness, installability, accessibility, and public API
+  stability over style preferences.
+- For registry component changes, verify that source, examples, docs,
+  `registry.json`, generated registry output, and install targets stay in sync.
+- Flag any component change that omits practical docs, examples, or validation
+  commands when the public API or behavior changes.
+- Treat generated files such as `public/r/**` and `registry/__index__.tsx` as
+  outputs. Review whether they match the source intent, not whether they should
+  be hand-edited.
+- For docs changes, check that commands use the current package manager,
+  component names match registry entries, and links point to maintained sources.
+- For GitHub automation changes, check permissions, third-party triggers,
+  maintainer-only controls, and whether public contributors can consume limited
+  service quota.
+- Keep review comments high signal: report concrete defects, regressions,
+  missing tests, stale docs, or unsafe automation behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,29 @@ Please include:
 - A closing keyword in the PR description, such as `Closes #123`, `Fixes #123`, or `Resolves #123`, when the PR should automatically close an issue after merge. See GitHub's guide on [linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).
 - The reason or context behind the change
 
+### AI-assisted PR review
+
+This repository is prepared for free, maintainer-triggered AI review on pull
+requests.
+
+- CodeRabbit: install the
+  [CodeRabbit GitHub App](https://docs.coderabbit.ai/platforms/github-com) for
+  the public `8starlabs/ui` repository. Open-source repositories are eligible
+  for CodeRabbit's OSS plan, and this repo's `.coderabbit.yaml` keeps automatic
+  reviews off so review quota is used only when maintainers opt in.
+- Maintainer trigger: comment `@coderabbitai full review` on a pull request for
+  a complete first pass, then use `@coderabbitai review` after follow-up commits
+  for incremental review. Maintainers can also apply the `review-ready` label to
+  request a CodeRabbit review without leaving a command comment.
+- Optional Codex trigger: if
+  [Codex code review](https://developers.openai.com/codex/integrations/github)
+  is enabled for this repository in ChatGPT/Codex settings, comment
+  `@codex review` on the pull request.
+- AI review is advisory. Human maintainers still own final approval, merge
+  decisions, and any requested changes.
+- Review guidance lives in `AGENTS.md`, which Codex reads directly and
+  CodeRabbit includes through its code-guidelines configuration.
+
 ## Project Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
+    "test": "node --test tests/*.test.mjs",
     "lint": "eslint .",
     "registry:build": "shadcn build && prettier --write \"public/r/*.json\" --cache",
     "registry:generate-index": "tsx ./scripts/generate-index.mts && prettier --write \"registry/**/*.{ts,tsx,json,mdx}\" --cache",

--- a/tests/review-automation.test.mjs
+++ b/tests/review-automation.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const workspaceRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+
+async function readWorkspaceFile(relativePath) {
+  try {
+    return await readFile(path.join(workspaceRoot, relativePath), "utf8");
+  } catch (error) {
+    throw new Error(`Missing workspace file: ${relativePath}`, {
+      cause: error
+    });
+  }
+}
+
+function requireIncludes(text, expected, label) {
+  if (!text.includes(expected)) {
+    throw new Error(`${label} is missing ${JSON.stringify(expected)}`);
+  }
+}
+
+function sectionAfter(text, heading) {
+  const start = text.indexOf(heading);
+  if (start === -1) {
+    return "";
+  }
+
+  const section = text.slice(start + heading.length);
+  const nextHeading = section.search(/\n\S/);
+  return nextHeading === -1 ? section : section.slice(0, nextHeading);
+}
+
+test("CodeRabbit config uses maintainer-triggered review controls", async () => {
+  const config = await readWorkspaceFile(".coderabbit.yaml");
+  const autoReview = sectionAfter(config, "  auto_review:");
+
+  requireIncludes(config, "enable_free_tier: true", "CodeRabbit config");
+  requireIncludes(autoReview, "    enabled: false", "auto_review settings");
+  requireIncludes(
+    autoReview,
+    "    auto_incremental_review: false",
+    "auto_review settings"
+  );
+  requireIncludes(autoReview, '      - "review-ready"', "auto_review labels");
+  requireIncludes(
+    autoReview,
+    '      - "[skip review]"',
+    "auto_review title exclusions"
+  );
+  requireIncludes(config, '    - "!pnpm-lock.yaml"', "path filters");
+  requireIncludes(config, '    - "!public/r/**"', "path filters");
+  requireIncludes(config, '    - "!registry/__index__.tsx"', "path filters");
+  requireIncludes(config, "  allow_non_org_members: false", "chat settings");
+  requireIncludes(config, "  auto_reply: false", "chat settings");
+});
+
+test("agent review guidelines cover repo-specific risk areas", async () => {
+  const agents = await readWorkspaceFile("AGENTS.md");
+
+  requireIncludes(agents, "## Review guidelines", "AGENTS.md");
+  requireIncludes(agents, "registry component changes", "review guidelines");
+  requireIncludes(agents, "`registry.json`", "review guidelines");
+  requireIncludes(agents, "`public/r/**`", "review guidelines");
+  requireIncludes(agents, "GitHub automation changes", "review guidelines");
+  requireIncludes(agents, "service quota", "review guidelines");
+});
+
+test("contributor docs explain CodeRabbit and Codex review triggers", async () => {
+  const contributing = await readWorkspaceFile("CONTRIBUTING.md");
+
+  requireIncludes(
+    contributing,
+    "https://docs.coderabbit.ai/platforms/github-com",
+    "CodeRabbit docs link"
+  );
+  requireIncludes(
+    contributing,
+    "https://developers.openai.com/codex/integrations/github",
+    "Codex docs link"
+  );
+  requireIncludes(contributing, "@coderabbitai full review", "CodeRabbit docs");
+  requireIncludes(contributing, "@coderabbitai review", "CodeRabbit docs");
+  requireIncludes(contributing, "review-ready", "CodeRabbit label docs");
+  requireIncludes(contributing, "@codex review", "Codex docs");
+  requireIncludes(contributing, "AI review is advisory", "review ownership");
+});
+
+test("pull request template exposes validation and AI review prompts", async () => {
+  const template = await readWorkspaceFile(".github/PULL_REQUEST_TEMPLATE.md");
+
+  requireIncludes(template, "## Validation", "pull request template");
+  requireIncludes(template, "`pnpm lint`", "validation checklist");
+  requireIncludes(template, "`pnpm tscheck`", "validation checklist");
+  requireIncludes(
+    template,
+    "`pnpm registry:generate-index`",
+    "validation checklist"
+  );
+  requireIncludes(template, "`pnpm registry:build`", "validation checklist");
+  requireIncludes(template, "Screenshots", "validation checklist");
+  requireIncludes(template, "@coderabbitai full review", "AI review checklist");
+  requireIncludes(template, "@coderabbitai review", "AI review checklist");
+  requireIncludes(template, "review-ready", "AI review checklist");
+  requireIncludes(template, "@codex review", "AI review checklist");
+});
+
+test("test helpers fail clearly for empty, missing, and malformed content", async () => {
+  assert.equal(sectionAfter("", "missing"), "");
+  assert.equal(sectionAfter("heading\nvalue", "absent"), "");
+  assert.throws(
+    () => requireIncludes("", "anything", "empty content"),
+    /empty content is missing "anything"/
+  );
+  await assert.rejects(
+    readWorkspaceFile("does-not-exist.md"),
+    /Missing workspace file: does-not-exist\.md/
+  );
+});


### PR DESCRIPTION
## Summary

Adds a free, maintainer-triggered AI review workflow for pull requests. The repository now includes CodeRabbit OSS configuration, Codex/CodeRabbit review guidance, contributor documentation, a PR template, and automated tests that keep the review setup from drifting.

## Key Changes

- Added `.coderabbit.yaml` with automatic reviews disabled by default, explicit maintainer opt-ins via `@coderabbitai` commands or the `review-ready` label, repo-specific path instructions, and conservative public-contributor chat settings.
- Added review guidance in `AGENTS.md` and contributor-facing setup instructions in `CONTRIBUTING.md` for CodeRabbit and optional `@codex review`.
- Added `.github/PULL_REQUEST_TEMPLATE.md`, `npm test`, and `tests/review-automation.test.mjs` to validate the review workflow contract.

## Validation

- `npm test`
- `pnpm lint`
- `pnpm build`
- `pnpm tscheck`
- Prettier check
- CodeRabbit schema validation
- Browser smoke check on `localhost:3001`

Closes #42
