### PR TITLE
chore: repo hardening — commit-msg hook + pnpm supply-chain config

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+# Enforce the conventional commit format documented in CONTRIBUTING.md.
+# Allowed types: feat, fix, docs, refactor, chore (with an optional scope).
+
+msg_file="$1"
+
+# First non-empty, non-comment line of the commit message.
+header=$(grep -v '^#' "$msg_file" | sed '/^[[:space:]]*$/d' | head -n1)
+
+# Let merge / revert / fixup / squash commits through untouched.
+case "$header" in
+  "Merge "* | "Revert "* | "fixup! "* | "squash! "*) exit 0 ;;
+esac
+
+pattern='^(feat|fix|docs|refactor|chore)(\([a-z0-9./_-]+\))?!?: .+'
+
+if printf '%s' "$header" | grep -Eq "$pattern"; then
+  exit 0
+fi
+
+echo "✖ Invalid commit message:"
+echo "    $header"
+echo ""
+echo "Commit messages must follow the conventional format (see CONTRIBUTING.md):"
+echo "    <type>: <description>"
+echo ""
+echo "Allowed types: feat, fix, docs, refactor, chore"
+echo "Example: feat: add new Button variant"
+exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,8 @@ This repository is a monorepo.
 
 Example: `git commit -m 'feat: add new Button variant'`
 
+This format is enforced automatically by a `commit-msg` git hook — commits whose subject does not start with one of the types above (with an optional scope) are rejected.
+
 6. **Push your branch**
 
    ```bash

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+# Supply-chain hardening: delay installing freshly published versions (7 days)
+# so malware caught and unpublished within hours never lands, and fail installs
+# when a package's trust signals (provenance/signatures) weaken between releases.
+minimumReleaseAge: 10080
+trustPolicy: no-downgrade
 overrides:
   esbuild: ">=0.28.1"
 allowBuilds:


### PR DESCRIPTION
## Summary

Two repo-hardening changes. First, a `commit-msg` git hook that enforces the conventional-commit format already documented in `CONTRIBUTING.md` — previously a convention only, with nothing enforcing it. Second, two pnpm supply-chain settings flagged by `react-doctor` (Security findings), aligning with the repo's existing posture (e.g. the earlier esbuild RCE override).

## Key Changes

Commit message enforcement:
- `.husky/commit-msg` — validates the subject against `^(feat|fix|docs|refactor|chore)(\(scope\))?!?: `, dependency-free (POSIX `sh` + `grep -E`, no commitlint). Lets `Merge`/`Revert`/`fixup!`/`squash!` through. Verified: accepts valid types, blocks junk.
- `CONTRIBUTING.md` — note that the format is now hook-enforced.

pnpm supply-chain hardening (`pnpm-workspace.yaml`):
- `minimumReleaseAge: 10080` — delay installing versions published <7 days ago, so malware caught and unpublished within hours never lands (pnpm 11 defaults to 1 day; this makes it explicit and stronger).
- `trustPolicy: no-downgrade` — fail installs when a package's trust signals (provenance/signatures) weaken between releases.
- Verified `pnpm install --frozen-lockfile` still resolves cleanly; `react-doctor` Security findings go 2 → 0.

## Note on react-doctor errors (not fixed — false positives)

`react-doctor` reports 3 `no-adjust-state-on-prop-change` errors (`components/docs-toc.tsx`, `registry/8starlabs-ui/blocks/scroll-fade.tsx`). All three are legitimate browser-observer / layout-measurement effects (IntersectionObserver scroll-spy; ResizeObserver edge-fade measurement) whose state isn't derivable during render — not the anti-pattern the rule targets. Left unchanged intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)